### PR TITLE
Attempt to force shared cache revalidation

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,7 +15,7 @@ class ApplicationController < ActionController::Base
       max_age: 1.hour,
       # Maximum length of time for public (e.g., CDN) caches
       public: true,
-      extras: ["s-maxage=0"],
+      extras: ["s-maxage=0", "must-revalidate", "proxy-revalidate"],
       stale_while_revalidate: 7.days,
       stale_if_error: 7.days,
     )


### PR DESCRIPTION
We are still not seeing the CDN revalidate in all cases. This is an attempt to set a few more header values to force it.