### PR TITLE
Remove jbuilder (unused)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,6 @@ gem "puma", ">= 5.0"
 gem "jsbundling-rails"
 # Bundle and process CSS [https://github.com/rails/cssbundling-rails]
 gem "cssbundling-rails"
-# Build JSON APIs with ease [https://github.com/rails/jbuilder]
-gem "jbuilder"
 # CSV
 gem "csv"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,9 +135,6 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    jbuilder (2.13.0)
-      actionview (>= 5.0.0)
-      activesupport (>= 5.0.0)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.12.2)
@@ -346,7 +343,6 @@ DEPENDENCIES
   cssbundling-rails
   csv
   debug
-  jbuilder
   jsbundling-rails
   pg (~> 1.5, < 1.6)
   propshaft


### PR DESCRIPTION
jbuilder is used for building JSON APIs, which is not needed for this project

Closes #51 