### PR TITLE
Silence noisy compilation warnings from sass

### DIFF
--- a/app/assets/stylesheets/_uswds-theme.scss
+++ b/app/assets/stylesheets/_uswds-theme.scss
@@ -10,7 +10,6 @@ in the form $setting: value,
 @use "uswds-core" with (
   $theme-font-path: "",
   $theme-image-path: "",
-  $theme-show-compile-warnings: false,
   $theme-show-notifications: false,
   $theme-site-margins-width: 2
 );

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "build": "esbuild app/javascript/*.* --bundle --sourcemap --format=esm --outdir=app/assets/builds --public-path=/assets",
-    "build:css": "sass ./app/assets/stylesheets/application.sass.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules --load-path=node_modules/@uswds/uswds/packages"
+    "build:css": "sass ./app/assets/stylesheets/application.sass.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules --load-path=node_modules/@uswds/uswds/packages --quiet-deps"
   },
   "dependencies": {
     "@uswds/uswds": "3.13.0",


### PR DESCRIPTION
This matches how EntryApplication is configured, and removes a lot of useless, noisy messages during asset compilation.